### PR TITLE
[Refactor] #46 : 자산 메인 페이지 수정하기

### DIFF
--- a/src/components/assetCharts/CompositionDonutChart.vue
+++ b/src/components/assetCharts/CompositionDonutChart.vue
@@ -8,25 +8,46 @@ ChartJS.register(Title, Tooltip, Legend, ArcElement, ChartDataLabels);
 // Props로 composition 객체 받기
 const props = defineProps({
   composition: Object,
+  balance: Number,
 });
 
 // 도넛 차트 데이터 구성
 const chartData = computed(() => {
-  if (!props.composition || !props.composition.assetComposition) return null;
-
-  const comp = props.composition.assetComposition;
-
-  return {
-    labels: Object.keys(comp),
+  const defaultData = {
+    labels: ["데이터 없음"],
     datasets: [
       {
-        data: Object.values(comp),
+        data: [100],
+        backgroundColor: ["#595959"], // Tailwind gray-200
+        borderWidth: 1,
+      },
+    ],
+  };
+
+  if (!props.composition || !props.composition.assetComposition) {
+    return defaultData;
+  }
+
+  const comp = props.composition.assetComposition;
+  const labels = Object.keys(comp);
+  const values = Object.values(comp);
+
+  // 값이 모두 0이거나 데이터가 없는 경우 → 기본 차트
+  if (!values.length || values.every((v) => v === 0)) {
+    return defaultData;
+  }
+
+  return {
+    labels,
+    datasets: [
+      {
+        data: values,
         backgroundColor: [
-          "#FBE081", // 기타
-          "#3B82F6", // 주식
-          "#10B981", // 채권
-          "#F87171", // 펀드
-          "#A78BFA", // 현금 및 예금
+          "#FFF3B0", // 기타
+          "#A0D8EF", // 주식
+          "#B2E2B8", // 채권
+          "#FFC4C4", // 펀드
+          "#D8C7FF", // 현금 및 예금
         ],
         borderWidth: 1,
       },
@@ -45,15 +66,25 @@ const chartOptions = {
         label: function (context) {
           const label = context.label || "";
           const value = context.raw;
-          return `${label}: ${value.toFixed(1)}%`;
+          const data = context.dataset.data;
+          const total = data.reduce((sum, val) => sum + val, 0);
+          const isDummy = data.length === 1 && value === 100;
+          if (isDummy) return null;
+
+          const totalBalance = props.balance || 0;
+          const percentage = ((value / total) * 100).toFixed(1);
+          const amount = Math.round((value / 100) * totalBalance);
+
+          return `${label}: ${percentage}% (${amount.toLocaleString()}원)`;
         },
       },
     },
+
     title: {
       display: false,
     },
     datalabels: {
-      color: "#383838", // Tailwind gray-700
+      color: "#595959",
       anchor: "center",
       align: "center",
       font: {
@@ -63,10 +94,10 @@ const chartOptions = {
       formatter: (value, context) => {
         const data = context.chart.data.datasets[0].data;
         const total = data.reduce((sum, val) => sum + val, 0);
+        if (!total || value === 100) return ""; // 기본 차트일 땐 라벨 안 보여줌
         const percentage = ((value / total) * 100).toFixed(1);
         return `${percentage}%`;
       },
-
       display: true,
     },
   },

--- a/src/components/common/ConnectSuccessModal.vue
+++ b/src/components/common/ConnectSuccessModal.vue
@@ -39,11 +39,11 @@ const handleConfirm = () => {
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <circle cx="30" cy="30" r="30" fill="#4CAF50" />
+          <circle cx="30" cy="30" r="30" fill="white" />
           <path
-            d="M25 30L28 33L35 26"
-            stroke="white"
-            stroke-width="3"
+            d="M20 31L27 38L42 23"
+            stroke="black"
+            stroke-width="4"
             stroke-linecap="round"
             stroke-linejoin="round"
           />

--- a/src/composables/api/useAssetApi.js
+++ b/src/composables/api/useAssetApi.js
@@ -1,14 +1,14 @@
 import apiClient from "@/plugins/axios";
 
-export const postConnectAccount = async (id, bankName) => {
+export const postConnectAccount = async (bankName) => {
   return await apiClient.post(
-    `http://localhost:8080/api/trainee/assets/account/${id}`,
+    `http://localhost:8080/api/trainee/assets/account`,
     {
       bank: bankName,
     },
   );
 };
 
-export const getTraineeAsset = async (id) => {
-  return await apiClient.get(`http://localhost:8080/api/trainee/assets/${id}`);
+export const getTraineeAsset = async () => {
+  return await apiClient.get(`http://localhost:8080/api/trainee/assets`);
 };

--- a/src/composables/asset/useCreateAsset.js
+++ b/src/composables/asset/useCreateAsset.js
@@ -4,9 +4,9 @@ import { postConnectAccount } from "@/composables/api/useAssetApi";
 export const useAccountConnect = () => {
   const router = useRouter();
 
-  const connectAccount = async (id, selectedBank) => {
+  const connectAccount = async (selectedBank) => {
     try {
-      const response = await postConnectAccount(id, selectedBank.name);
+      const response = await postConnectAccount(selectedBank.name);
 
       return {
         success: true,

--- a/src/composables/asset/useFetchAsset.js
+++ b/src/composables/asset/useFetchAsset.js
@@ -8,10 +8,10 @@ export const useTraineeAsset = () => {
   const errorMessage = ref(null);
   const isLoading = ref(false);
 
-  const getTraineeAsset = async (id) => {
+  const getTraineeAsset = async () => {
     isLoading.value = true;
     try {
-      const response = await fetchTraineeAsset(id);
+      const response = await fetchTraineeAsset();
       assetData.value = response.data.data;
       return { success: true, data: response.data };
     } catch (error) {


### PR DESCRIPTION
## 📑 이슈 번호
- #46 

## ✨️ 작업 내용
- [x] 데이터 없을 경우에 회색 도넛 차트 
- [x] 은행 복수 선택 가능 (프론트에서만)
- [x] 차트 색상 파스텔 색상으로
- [x] awaitUserReady로 userId 가져오도록 수정
- [x] 성공 모달창 변경

## 💙 코멘트(선택)
<img width="400" height="200" alt="image" src="https://github.com/user-attachments/assets/94ffdb3f-d977-48fa-b0a7-05ba20d80ea0" />

자산 추이 선 차트의 경우 데이터 없는 경우 디폴트 차트 형태가 안 이쁨

## 📸 구현 결과(선택)
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/1dad5106-fe8c-4014-98ba-7aa271b33da2" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/f52c9eb8-359d-4089-baeb-d8f48809d999" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/ad359999-5ad0-4f82-9c1c-5f2bfcb79dbb" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/4058c475-2550-41e2-b064-0f6b2cc35814" />
<img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/bff92efc-9900-4782-85b9-9ee1a42f0cb4" />
