### PR TITLE
[Fix] #58 :  로그인 상태 유지 및 토큰 이슈

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { createPinia } from "pinia";
 
 import App from "./App.vue";
 import router from "./router";
+import { useAuthStore } from "@/stores/auth";
 
 import "@/assets/styles/tailwind.css";
 import "@/plugins/fontawesome";
@@ -13,6 +14,16 @@ const app = createApp(App);
 const pinia = createPinia();
 
 app.use(pinia);
+
+// 앱 시작 시 localStorage에서 토큰을 확인하고 사용자 정보를 가져옵니다.
+const authStore = useAuthStore();
+const token = localStorage.getItem("accessToken");
+
+if (token) {
+  authStore.setToken(token);
+  await authStore.fetchUserInfo(); // fetchUserInfo가 완료될 때까지 기다립니다.
+}
+
 app.use(router);
 
 app.component("font-awesome-icon", FontAwesomeIcon);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -124,6 +124,10 @@ const router = createRouter({
 router.beforeEach(async (to, from, next) => {
   const authStore = useAuthStore();
 
+  if (to.path === "/login") {
+    authStore.logout();
+  }
+
   const requiresAuth = to.meta.requiresAuth;
   const requiredRoles = to.meta.roles;
   const isAuthenticated = !!authStore.token;
@@ -139,7 +143,7 @@ router.beforeEach(async (to, from, next) => {
         return next();
       } else {
         alert("접근 권한이 없습니다.");
-        return next("/");
+        return next("/login");
       }
     }
     return next();


### PR DESCRIPTION
새로고침 시 로그인 상태 유지
로그인 페이지 진입 시 기존 세션 제거

## 📑 이슈 번호
- close #58

## ✨️ 작업 내용
- [x] 토큰이 존재할 경우, 해당 토큰을 사용하여 서버로부터 사용자 정보를 다시 가져와 Pinia 스토어의 상태를 복원하도록 로직을 추가
- [x] Vue Router의 네비게이션 가드(`router.beforeEach`)를 수정하여, `/login` 경로로 진입할 때마다 `authStore.logout()` 액션을 호출하도록 변경

## 💙 코멘트(선택)

## 📸 구현 결과(선택)
<img width="728" height="409" alt="스크린샷 2025-08-04 오후 1 25 56" src="https://github.com/user-attachments/assets/8af0dcb9-0cda-48c3-ad76-52a4cf886994" />