### PR TITLE
[Feature] #82 : 채팅방 생성/이동 및 프로필 이미지 적용 기능 구현

### DIFF
--- a/src/components/chat/ChatBubble.vue
+++ b/src/components/chat/ChatBubble.vue
@@ -4,36 +4,24 @@ import { UserIcon } from "lucide-vue-next";
 import profileImg from "@/assets/images/mascot/profile.png";
 
 const props = defineProps({
-  message: {
-    type: String,
-    required: true,
-  },
-  timestamp: {
-    type: String,
-    required: true,
-  },
-  isOwn: {
-    type: Boolean,
-    default: false,
-  },
-  profileUrl: {
-    type: String,
-    required: false,
-  },
-  isAiChat: {
-    type: Boolean,
-    default: false,
-  },
+  message: String,
+  timestamp: String,
+  isOwn: Boolean,
+  profileUrl: String,
+  isAiChat: Boolean,
 });
 
-const messageClasses = computed(() => {
-  return props.isOwn
+const messageClasses = computed(() =>
+  props.isOwn
     ? "bg-primary text-black rounded-br-sm"
-    : "bg-white text-black rounded-bl-sm";
-});
+    : "bg-white text-black rounded-bl-sm",
+);
 
 const profileImage = computed(() => {
-  return props.isAiChat ? profileImg : props.profileUrl || UserIcon;
+  if (props.isAiChat && !props.isOwn) {
+    return profileImg;
+  }
+  return props.profileUrl || null;
 });
 </script>
 
@@ -46,7 +34,7 @@ const profileImage = computed(() => {
       v-if="!isOwn"
       class="mr-2 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-white"
     >
-      <template v-if="profileUrl">
+      <template v-if="profileImage">
         <img
           :src="profileImage"
           alt="프로필 이미지"
@@ -74,7 +62,7 @@ const profileImage = computed(() => {
       v-if="isOwn"
       class="ml-2 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-white"
     >
-      <template v-if="profileUrl">
+      <template v-if="profileImage">
         <img
           :src="profileImage"
           alt="내 프로필 이미지"

--- a/src/components/chat/ChatListItem.vue
+++ b/src/components/chat/ChatListItem.vue
@@ -35,6 +35,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  opponentProfileUrl: {
+    type: String,
+    default: false,
+  },
 });
 
 defineEmits(["click"]);
@@ -68,7 +72,16 @@ const remainingDaysClass = computed(() => {
       <div
         class="flex h-12 w-12 items-center justify-center rounded-full bg-gray-600"
       >
-        <UserIcon class="h-6 w-6 text-gray-300" />
+        <template v-if="opponentProfileUrl">
+          <img
+            :src="opponentProfileUrl"
+            alt="상대방 프로필"
+            class="h-12 w-12 object-cover"
+          />
+        </template>
+        <template v-else>
+          <UserIcon class="h-6 w-6 text-gray-300" />
+        </template>
       </div>
       <div
         v-if="unreadCount > 0"

--- a/src/composables/api/useCounselingApi.js
+++ b/src/composables/api/useCounselingApi.js
@@ -18,3 +18,10 @@ export async function readMessages(roomId, userId) {
     userId,
   });
 }
+
+export async function createCounseling(trainingId, traineeId) {
+  return await apiClient.post(`/api/common/counselings`, {
+    trainingId,
+    traineeId,
+  });
+}

--- a/src/views/chat/PtHistoryPage.vue
+++ b/src/views/chat/PtHistoryPage.vue
@@ -93,6 +93,7 @@ const fetchChatList = async () => {
         unreadCount: item.unreadCount,
         isExpired,
         roomId: item.roomId,
+        opponentProfileUrl: item.opponentProfileUrl,
       };
     });
   } catch (error) {
@@ -157,6 +158,7 @@ onBeforeUnmount(async () => {
         :timestamp="chat.timestamp"
         :unread-count="chat.unreadCount"
         :is-expired="chat.isExpired"
+        :opponent-profile-url="chat.opponentProfileUrl"
         @click="handleChatClick"
       />
 

--- a/src/views/trainee/TraineeTrainingDetailPage.vue
+++ b/src/views/trainee/TraineeTrainingDetailPage.vue
@@ -2,23 +2,27 @@
 import { ref, computed, onMounted } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import { getTraineeTrainingDetail } from "@/composables/api/trainee/training/traineeTrainingDetailAPI";
+import { createCounseling } from "@/composables/api/useCounselingApi";
 
 import BaseHeader from "@/components/common/BaseHeader.vue";
 import BaseBadge from "@/components/common/BaseBadge.vue";
 import TraineeRoutineSection from "@/components/trainee/training/TraineeRoutineSection.vue";
 import ActionButton from "@/components/trainee/training/ActionButton.vue";
 import DoughnutChart from "@/components/trainee/training/DoughnutChart.vue";
+import { useAuthStore } from "@/stores/auth";
 
 const router = useRouter();
 const route = useRoute();
+const authStore = useAuthStore();
 
 const trainingData = ref(null);
+const trainingId = ref(route.params.trainingId);
+const userId = authStore.userId;
 
 // ✅ API 호출 및 데이터 매핑 (Map → 배열 변환)
 const loadTrainingData = async () => {
   try {
-    const trainingId = route.params.trainingId;
-    const res = await getTraineeTrainingDetail(trainingId);
+    const res = await getTraineeTrainingDetail(trainingId.value);
     const raw = res.data.data;
 
     // ✅ Map 데이터를 배열로 변환하면서 id/name 필드 생성
@@ -129,6 +133,22 @@ const showChatButton = computed(() => areAllQuestsComplete.value);
 const showReviewButton = computed(
   () => areAllQuestsComplete.value || isTrainingExpired.value,
 );
+
+const startChat = async () => {
+  try {
+    const response = await createCounseling(trainingId.value, userId);
+
+    if (response.data.success && response.data.data?.roomId) {
+      alert("채팅방이 생성되었습니다.");
+      router.push(`/common/pt-chat/${response.data.data.roomId}`);
+    } else {
+      throw new Error(response.data.message || "채팅방 생성에 실패했습니다.");
+    }
+  } catch (err) {
+    console.error("🚨 채팅방 생성 실패:", err);
+    alert("채팅방 생성 중 오류가 발생했습니다. 다시 시도해주세요.");
+  }
+};
 </script>
 
 <template>
@@ -242,6 +262,7 @@ const showReviewButton = computed(
           v-if="showChatButton"
           text="트레이너와 1:1 채팅하기"
           variant="primary"
+          @click="startChat"
         >
           <template #icon>
             <img

--- a/src/views/trainee/asset/AssetAiChatPage.vue
+++ b/src/views/trainee/asset/AssetAiChatPage.vue
@@ -186,6 +186,7 @@ const handleFetchAssetsAndSendMessage = async () => {
         <ChatBubble
           v-for="message in group"
           :key="message.id"
+          isAiChat="true,"
           :message="message.text"
           :is-own="message.isOwn"
           :timestamp="message.timestamp"


### PR DESCRIPTION
## 📑 이슈 번호
- #11

## ✨️ 작업 내용
- [ ] 채팅방 생성 버튼 클릭 시 채팅방 생성 API 호출 및 `roomId` 응답 처리
- [ ] `roomId`를 기반으로 `/common/pt-chat/{roomId}`로 라우팅 처리
- [ ] AI 컨설팅 상대방 프로필 금육이 프로필 이미지 사용

## 💙 코멘트(선택)

## 📸 구현 결과(선택)
