### PR TITLE
[Refactor] #153 : 루틴 상세 페이지_수행처리 디자인 변경, 결과 모달 디자인 변경

### DIFF
--- a/src/components/trainee/training/RoutineResultModal.vue
+++ b/src/components/trainee/training/RoutineResultModal.vue
@@ -1,113 +1,123 @@
 <script setup>
 const props = defineProps({
   isVisible: { type: Boolean, required: true },
-  status: { type: String, default: "success" }, // 'success' 또는 'failure'
+  status: { type: String, default: "success" }, // 'success' | 'failure'
   reward: { type: Number, default: 1 },
 });
 
 const emit = defineEmits(["close", "retry"]);
 
-const handleConfirm = () => {
-  if (props.status === "success") {
-    emit("close");
-  } else {
-    emit("retry");
-  }
+const handlePrimary = () => {
+  if (props.status === "success") emit("close");
+  else emit("retry");
 };
 </script>
 
 <template>
   <div
     v-if="isVisible"
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70 backdrop-blur-sm"
+    class="fixed inset-0 z-[999] flex items-center justify-center bg-black/80"
+    role="dialog"
+    aria-modal="true"
   >
+    <!-- 공통 카드 -->
     <div
-      v-if="status === 'success'"
-      class="w-11/12 max-w-xs rounded-2xl bg-white p-6 text-center text-black shadow-lg"
+      class="w-[90%] max-w-[340px] rounded-2xl bg-[#1A1A1A] p-5 text-center text-white shadow-[0_18px_40px_rgba(0,0,0,0.6)]"
     >
-      <div class="flex justify-end">
-        <button @click="$emit('close')"><img src="@/assets/images/trainee/training/close_black.svg" alt="닫기"></img></button>
-      </div>
-      <div
-        class="mx-auto -mt-2 mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary"
+      <!-- 닫기 -->
+      <button
+        class="mb-1 ml-auto block rounded-full p-1 text-gray-400 hover:text-white"
+        aria-label="닫기"
+        @click="$emit('close')"
       >
-        <img src="@/assets/images/trainee/training/star_black.svg" alt="별" />
-      </div>
-      <h2 class="text-xl font-bold text-black">리워드 획득!</h2>
+        <!-- X 아이콘 -->
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M6 6l12 12M18 6L6 18"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
 
-      <div class="mt-4 rounded-xl border border-yellow-200 bg-yellow-50 p-4">
-        <div
-          class="flex items-center justify-center gap-2 font-bold text-black"
+      <!-- 상단 원형 아이콘 -->
+      <div
+        class="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full"
+        :class="status === 'success' ? 'bg-primary' : 'bg-[#3A3A3A]'"
+      >
+        <svg
+          v-if="status === 'success'"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
         >
-          <div
-            class="flex h-6 w-6 items-center justify-center rounded-full bg-primary"
-          >
-            <img
-              src="@/assets/images/trainee/training/star_black.svg"
-              alt="별"
-              class="h-2 w-2"
-            />
+          <path
+            d="M20 6L9 17l-5-5"
+            stroke="#0B0B0B"
+            stroke-width="3"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <svg v-else width="20" height="20" viewBox="0 0 24 24" fill="none">
+          <path
+            d="M6 6l12 12M18 6L6 18"
+            stroke="#0B0B0B"
+            stroke-width="3"
+            stroke-linecap="round"
+          />
+        </svg>
+      </div>
+
+      <!-- 타이틀/서브텍스트 -->
+      <template v-if="status === 'success'">
+        <h2 class="text-[18px] font-extrabold text-primary">리워드 획득!</h2>
+        <p class="mt-1 text-body2 text-gray-300">
+          루틴을 성공적으로 완료했습니다
+        </p>
+
+        <!-- 포인트 박스 -->
+        <div class="mt-5 rounded-xl border border-[#2A2A2A] bg-[#141414] p-4">
+          <div class="text-body3 text-gray-400">획득 포인트</div>
+          <div class="mt-1 text-[22px] font-extrabold text-white">
+            {{ reward }}P
           </div>
-          <span>{{ reward }} 포인트</span>
         </div>
 
-        <p class="mt-2 text-sm text-gray-600">
-          루틴을 성공적으로 완료하여<br />리워드 포인트를 획득했습니다!
-        </p>
-      </div>
-      <div class="mt-6">
         <button
-          @click="handleConfirm"
-          class="w-full rounded-lg bg-primary py-3 font-bold text-black transition-opacity duration-200 hover:opacity-80"
+          class="mt-6 w-full rounded-lg bg-primary py-3 font-bold text-black hover:opacity-90"
+          @click="handlePrimary"
         >
           확인
         </button>
-      </div>
-    </div>
+      </template>
 
-    <div
-      v-else
-      class="w-11/12 max-w-xs rounded-2xl bg-white p-6 text-center text-black shadow-lg"
-    >
-      <div class="flex justify-end">
-        <button @click="$emit('close')"><img src="@/assets/images/trainee/training/close_black.svg" alt="닫기" /></button>
-      </div>
-      <div
-        class="mx-auto -mt-2 mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-300"
-      >
-        <img src="@/assets/images/trainee/training/close_red.svg" alt="오답" class="h-6 w-6" />
-      </div>
-      <h2 class="text-xl font-bold">오답입니다!</h2>
-      
-      
-      <div class="mt-4 rounded-xl border border-red-200 bg-red-50 p-4">
+      <template v-else>
+        <h2 class="text-[18px] font-extrabold text-gray-100">
+          리워드 획득 실패
+        </h2>
+        <p class="mt-1 text-body2 text-gray-300">루틴을 완료하지 못했습니다</p>
+
+        <!-- 안내 박스 -->
         <div
-          class="flex items-center justify-center gap-2 font-bold text-black"
+          class="mt-5 space-y-2 rounded-xl border border-[#2A2A2A] bg-[#141414] p-4 text-left"
         >
-          <div
-            class="flex h-6 w-6 items-center justify-center rounded-full bg-red-300"
-          >
-            <img
-              src="@/assets/images/trainee/training/close_red.svg" alt="오답"
-              class="h-2 w-2"
-            />
-          </div>
-          <span class="text-red-500">다시 시도</span>
+          <p class="text-body3 text-gray-300">실패 사유</p>
+          <ul class="list-disc space-y-1 pl-5 text-body3 text-gray-400">
+            <li>정답이 일치하지 않았습니다</li>
+            <li>사진이 명확하지 않거나 판독이 어려웠습니다</li>
+          </ul>
         </div>
 
-        <p class="mt-2 text-sm text-gray-600">
-          정답이 아닙니다.<br />다시 한번 시도해보세요!
-        </p>
-      </div>
-
-      <div class="mt-6">
         <button
-          @click="handleConfirm"
-          class="w-full rounded-xl bg-red-300 py-3 font-bold text-red-500 transition-opacity duration-200 hover:opacity-80"
+          class="mt-6 w-full rounded-lg bg-primary py-3 font-bold text-black hover:opacity-90"
+          @click="handlePrimary"
         >
-          다시 시도
+          다시 시도하기
         </button>
-      </div>
+      </template>
     </div>
   </div>
 </template>

--- a/src/components/trainee/training/RoutineTypeOX.vue
+++ b/src/components/trainee/training/RoutineTypeOX.vue
@@ -1,5 +1,7 @@
 <script setup>
 import { ref, computed } from "vue";
+import BaseSelectButton from "@/components/common/BaseSelectButton.vue";
+
 const props = defineProps({
   title: String,
   description: String,
@@ -9,61 +11,42 @@ const props = defineProps({
 const emit = defineEmits(["submit"]);
 
 const choice = ref(null); // 'O' | 'X'
-const reason = ref("");
 
+// 선택된 경우만 제출 가능
 const canSubmit = computed(() => !!choice.value);
 
+// 서버에는 항상 대문자 'O' 또는 'X'만 보냄
 const onSubmit = () => {
   if (!canSubmit.value || props.loading) return;
-  const text = `[${choice.value}] ${reason.value || ""}`.trim();
-  emit("submit", { text });
+  emit("submit", { text: String(choice.value).toUpperCase() });
 };
 </script>
 
 <template>
   <!-- 전체 모드 -->
   <section v-if="!minimal" class="space-y-4">
+    <!-- 상단 설명 카드 -->
     <div class="rounded-xl bg-gray-900 p-4">
       <div class="mb-2 flex items-center gap-2">
         <h3 class="font-bold text-white">{{ title }}</h3>
         <span
           class="rounded-full bg-[#3A3A3A] px-2 py-[2px] text-[11px] leading-none text-white"
-          >OX</span
         >
+          OX
+        </span>
       </div>
       <p class="text-gray-300">{{ description }}</p>
     </div>
 
-    <div class="space-y-4 rounded-xl bg-gray-900 p-4">
-      <div class="flex items-center gap-2">
-        <button
-          class="flex-1 rounded-lg py-3 font-bold"
-          :class="
-            choice === 'O' ? 'bg-primary text-black' : 'bg-[#1A1A1A] text-white'
-          "
-          @click="choice = 'O'"
-        >
-          O
-        </button>
-        <button
-          class="flex-1 rounded-lg py-3 font-bold"
-          :class="
-            choice === 'X' ? 'bg-primary text-black' : 'bg-[#1A1A1A] text-white'
-          "
-          @click="choice = 'X'"
-        >
-          X
-        </button>
-      </div>
+    <!-- 답안 선택: 공용 컴포넌트로 대체 -->
+    <div class="space-y-3 rounded-xl bg-gray-900 p-4">
+      <div class="text-body3 text-gray-400">답안 선택</div>
 
-      <textarea
-        v-model="reason"
-        placeholder="설명을 덧붙이고 싶다면 입력해주세요(선택)"
-        class="h-24 w-full resize-none rounded-lg bg-[#141414] p-3 text-white outline-none placeholder:text-gray-500"
-      />
+      <!-- v-model 이 선택값('O' | 'X')를 바인딩 -->
+      <BaseSelectButton v-model="choice" :options="['O', 'X']" />
 
       <button
-        class="w-full rounded-lg bg-primary py-3 font-bold text-black disabled:opacity-70"
+        class="mt-2 w-full rounded-lg bg-primary py-3 font-bold text-black disabled:opacity-70"
         :disabled="!canSubmit || loading"
         @click="onSubmit"
       >
@@ -72,34 +55,11 @@ const onSubmit = () => {
     </div>
   </section>
 
-  <!-- minimal 모드 -->
-  <section v-else class="space-y-5">
-    <div class="flex items-center gap-2">
-      <button
-        class="flex-1 rounded-lg py-3 font-bold"
-        :class="
-          choice === 'O' ? 'bg-primary text-black' : 'bg-[#1A1A1A] text-white'
-        "
-        @click="choice = 'O'"
-      >
-        O
-      </button>
-      <button
-        class="flex-1 rounded-lg py-3 font-bold"
-        :class="
-          choice === 'X' ? 'bg-primary text-black' : 'bg-[#1A1A1A] text-white'
-        "
-        @click="choice = 'X'"
-      >
-        X
-      </button>
-    </div>
+  <!-- 모달에서 쓰는 최소 모드 -->
+  <section v-else class="space-y-6">
+    <div class="text-body3 text-gray-400">답안 선택</div>
 
-    <textarea
-      v-model="reason"
-      placeholder="설명(선택)"
-      class="h-24 w-full resize-none rounded-lg bg-[#141414] p-3 text-white outline-none placeholder:text-gray-500"
-    />
+    <BaseSelectButton v-model="choice" :options="['O', 'X']" />
 
     <button
       class="w-full rounded-lg bg-primary py-3 font-bold text-black disabled:opacity-70"

--- a/src/components/trainee/training/RoutineTypePractice.vue
+++ b/src/components/trainee/training/RoutineTypePractice.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, onBeforeUnmount } from "vue";
+
 const props = defineProps({
   title: String,
   description: String,
@@ -9,23 +10,60 @@ const props = defineProps({
 const emit = defineEmits(["submit"]);
 
 const memo = ref("");
-const file = ref(null);
+const file = ref(/** @type {File|null} */ null);
 const url = ref("");
 
+const fileInput = ref(null);
+let previewObjectUrl = null;
+const previewUrl = ref("");
+
 const hasEvidence = computed(() => !!file.value || url.value.trim().length > 0);
+
+const revokePreview = () => {
+  if (previewObjectUrl) URL.revokeObjectURL(previewObjectUrl);
+  previewObjectUrl = null;
+};
+
+const setPreview = (f) => {
+  revokePreview();
+  if (f) {
+    previewObjectUrl = URL.createObjectURL(f);
+    previewUrl.value = previewObjectUrl;
+  } else {
+    previewUrl.value = "";
+  }
+};
 
 const onFileChange = (e) => {
   const f = e.target.files?.[0];
   file.value = f ?? null;
+  setPreview(file.value);
 };
+
+const onDrop = (e) => {
+  const f = e.dataTransfer?.files?.[0];
+  if (!f) return;
+  file.value = f;
+  setPreview(f);
+};
+
+const triggerPicker = () => fileInput.value?.click();
+
+const removeFile = () => {
+  file.value = null;
+  setPreview(null);
+};
+
 const onSubmit = () => {
   if (!hasEvidence.value || props.loading) return;
+  const joinedText = [memo.value, url.value].filter(Boolean).join("\n");
   emit("submit", {
-    text: memo.value,
-    imageFile: file.value,
-    imageUrl: url.value || undefined,
+    text: joinedText, // 서버는 answerText만 받음(메모+URL 합쳐서 전달)
+    imageFile: file.value || null, // 파일 있으면 전달
   });
 };
+
+onBeforeUnmount(revokePreview);
 </script>
 
 <template>
@@ -36,72 +74,140 @@ const onSubmit = () => {
         <h3 class="font-bold text-white">{{ title }}</h3>
         <span
           class="rounded-full bg-[#3A3A3A] px-2 py-[2px] text-[11px] leading-none text-white"
-          >실천형</span
         >
+          실천형
+        </span>
       </div>
       <p class="text-gray-300">{{ description }}</p>
     </div>
 
-    <div class="space-y-4 rounded-xl bg-gray-900 p-4">
-      <label
-        class="block cursor-pointer rounded-lg bg-[#1A1A1A] p-4 text-center text-gray-300"
+    <!-- 업로드 박스 -->
+    <div class="rounded-xl bg-[#0F0F0F] p-4">
+      <p class="mb-2 text-body2 text-gray-400">인증 사진 업로드</p>
+
+      <div
+        class="cursor-pointer rounded-xl border border-dashed border-gray-700 bg-[#121212] p-4 text-center text-gray-300 transition hover:bg-[#141414]"
+        @click="triggerPicker"
+        @dragover.prevent
+        @drop.prevent="onDrop"
       >
         <input
+          ref="fileInput"
           type="file"
           accept="image/*"
           class="hidden"
           @change="onFileChange"
         />
-        증빙 이미지 업로드
-      </label>
 
-      <input
-        v-model="url"
-        placeholder="또는 증빙 URL을 입력하세요(선택)"
-        class="w-full rounded-lg bg-[#1A1A1A] p-3 text-white outline-none placeholder:text-gray-500"
-      />
+        <!-- 선택 전 -->
+        <div
+          v-if="!file"
+          class="flex flex-col items-center justify-center py-6"
+        >
+          <!-- 업로드 아이콘 -->
+          <svg
+            viewBox="0 0 24 24"
+            class="h-8 w-8 text-gray-500"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 16V4m0 0 4 4m-4-4-4 4M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"
+            />
+          </svg>
+          <p class="mt-3 font-semibold text-white">사진을 업로드해주세요</p>
+          <p class="mt-1 text-body3 text-gray-500">
+            JPG, PNG 확장자 업로드 가능합니다
+          </p>
+        </div>
 
-      <textarea
-        v-model="memo"
-        placeholder="메모(선택)"
-        class="h-24 w-full resize-none rounded-lg bg-[#141414] p-3 text-white outline-none placeholder:text-gray-500"
-      />
-
-      <button
-        class="w-full rounded-lg bg-primary py-3 font-bold text-black disabled:opacity-70"
-        :disabled="!hasEvidence || loading"
-        @click="onSubmit"
-      >
-        제출하기
-      </button>
+        <!-- 선택 후 -->
+        <div v-else class="flex items-center gap-3 text-left">
+          <img
+            :src="previewUrl"
+            alt="preview"
+            class="h-14 w-14 rounded-lg object-cover"
+          />
+          <div class="flex-1">
+            <p class="truncate text-body text-white">{{ file.name }}</p>
+            <button
+              class="mt-1 text-body3 text-gray-400 underline underline-offset-2 hover:text-white"
+              @click.stop="removeFile"
+            >
+              변경/삭제
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
+
+    <button
+      class="w-full rounded-lg bg-primary py-3 font-bold text-black disabled:opacity-70"
+      :disabled="!hasEvidence || loading"
+      @click="onSubmit"
+    >
+      제출하기
+    </button>
   </section>
 
-  <!-- minimal 모드 -->
+  <!-- 모달용(minimal) -->
   <section v-else class="space-y-5">
-    <label
-      class="block cursor-pointer rounded-lg bg-[#1A1A1A] p-4 text-center text-gray-300"
+    <p class="text-body2 text-gray-400">인증 사진 업로드</p>
+
+    <div
+      class="cursor-pointer rounded-xl border border-dashed border-gray-700 bg-[#121212] p-4 text-center text-gray-300 transition hover:bg-[#141414]"
+      @click="triggerPicker"
+      @dragover.prevent
+      @drop.prevent="onDrop"
     >
       <input
+        ref="fileInput"
         type="file"
         accept="image/*"
         class="hidden"
         @change="onFileChange"
       />
-      증빙 이미지 업로드
-    </label>
 
-    <input
-      v-model="url"
-      placeholder="또는 증빙 URL(선택)"
-      class="w-full rounded-lg bg-[#1A1A1A] p-3 text-white outline-none placeholder:text-gray-500"
-    />
+      <div v-if="!file" class="flex flex-col items-center justify-center py-6">
+        <svg
+          viewBox="0 0 24 24"
+          class="h-8 w-8 text-gray-500"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 16V4m0 0 4 4m-4-4-4 4M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"
+          />
+        </svg>
+        <p class="mt-3 font-semibold text-white">사진을 업로드해주세요</p>
+        <p class="mt-1 text-body3 text-gray-500">
+          JPG, PNG 확장자 업로드 가능합니다
+        </p>
+      </div>
 
-    <textarea
-      v-model="memo"
-      placeholder="메모(선택)"
-      class="h-24 w-full resize-none rounded-lg bg-[#141414] p-3 text-white outline-none placeholder:text-gray-500"
-    />
+      <div v-else class="flex items-center gap-3 text-left">
+        <img
+          :src="previewUrl"
+          alt="preview"
+          class="h-14 w-14 rounded-lg object-cover"
+        />
+        <div class="flex-1">
+          <p class="truncate text-body text-white">{{ file.name }}</p>
+          <button
+            class="mt-1 text-body3 text-gray-400 underline underline-offset-2 hover:text-white"
+            @click.stop="removeFile"
+          >
+            변경/삭제
+          </button>
+        </div>
+      </div>
+    </div>
 
     <button
       class="w-full rounded-lg bg-primary py-3 font-bold text-black disabled:opacity-70"

--- a/src/views/trainee/TraineeRoutineDetailPage.vue
+++ b/src/views/trainee/TraineeRoutineDetailPage.vue
@@ -11,10 +11,14 @@ import RoutineChat from "@/components/trainee/training/RoutineChat.vue";
 import RoutineVideo from "@/components/trainee/training/RoutineVideo.vue";
 import RoutineResultModal from "@/components/trainee/training/RoutineResultModal.vue";
 
-// 타입별 폼
 import RoutineTypeSubjective from "@/components/trainee/training/RoutineTypeSubjective.vue";
 import RoutineTypeOX from "@/components/trainee/training/RoutineTypeOX.vue";
 import RoutineTypePractice from "@/components/trainee/training/RoutineTypePractice.vue";
+
+// 카테고리 아이콘
+import IconStretch from "@/assets/images/mascot/routine/Geumyuk_stretching.png";
+import IconStrength from "@/assets/images/mascot/routine/Geumyuk_strength.png";
+import IconCardio from "@/assets/images/mascot/routine/Geumyuk_cardio.png";
 
 const router = useRouter();
 const route = useRoute();
@@ -22,21 +26,17 @@ const enrollmentStore = useEnrollmentStore();
 const routineLock = useRoutineLockStore();
 
 const currentRoutine = ref(null);
-
-// 제출/채팅
 const certificationPhotos = ref([]);
 const isLoading = ref(false);
 const isResultModalVisible = ref(false);
 const submissionStatus = ref("success");
 const acquiredReward = ref(0);
 
-// 잠금/입력 모드
 const isLocked = ref(false);
 const isEntryMode = computed(
   () => !!route.query.enrollmentId && !isLocked.value,
 );
 
-// 타입/레이블
 const routineType = computed(() => currentRoutine.value?.type || "SUBJECTIVE");
 const isSubjective = computed(() => routineType.value === "SUBJECTIVE");
 const isOX = computed(() => routineType.value === "OX");
@@ -45,7 +45,25 @@ const typeLabel = computed(() =>
   isOX.value ? "OX" : isPractice.value ? "실천형" : "주관식",
 );
 
-// 상세 로드
+const routineGroup = computed(() => {
+  const raw = String(
+    route.query.group || currentRoutine.value?.category || "",
+  ).trim();
+  if (/근력/.test(raw)) return "근력";
+  if (/유산소/.test(raw)) return "유산소";
+  return "스트레칭";
+});
+const groupIcon = computed(() => {
+  switch (routineGroup.value) {
+    case "근력":
+      return IconStrength;
+    case "유산소":
+      return IconCardio;
+    default:
+      return IconStretch;
+  }
+});
+
 const loadRoutineDetail = async () => {
   try {
     const res = await getRoutineDetail(route.params.routineId);
@@ -92,13 +110,12 @@ onMounted(async () => {
 
 watch(
   () => route.query.enrollmentId,
-  async (val) => {
-    if (val) await loadRoutineDetail();
+  async (v) => {
+    if (v) await loadRoutineDetail();
   },
 );
 
 const handleGoBack = () => router.back();
-
 const openVideo = () => {
   if (currentRoutine.value?.videoUrl)
     window.open(currentRoutine.value.videoUrl, "_blank");
@@ -159,9 +176,7 @@ const handleCertificationSubmit = async (submission) => {
   }
 };
 
-const closeModal = () => {
-  router.back();
-};
+const closeModal = () => router.back();
 const closeResult = () => {
   isResultModalVisible.value = false;
 };
@@ -172,22 +187,19 @@ const retrySubmission = () => {
 
 <template>
   <div class="flex h-screen flex-col bg-realBlack">
-    <!-- 헤더 -->
     <header class="flex-shrink-0 px-6 pt-4">
       <BaseHeader title="루틴 상세" @back="handleGoBack" />
     </header>
 
-    <!-- 본문 -->
     <main
       v-if="currentRoutine"
       class="relative flex-1 overflow-y-auto px-6 pb-24 pt-4 scrollbar-hide"
     >
-      <!-- ====== 1) 영상 있는 케이스: 페이지 레이아웃 ====== -->
+      <!-- 1) 영상 있는 케이스 -->
       <template v-if="currentRoutine.videoUrl">
-        <!-- 타이틀/타입칩/설명 -->
         <div class="mb-6">
-          <div class="mb-1 flex items-center gap-2">
-            <h2 class="text-title font-bold text-white">
+          <div class="mb-1 mt-2 flex items-center gap-2">
+            <h2 class="text-subTtile2 mb-0.5 mt-0.5 font-bold text-white">
               {{ currentRoutine.title }}
             </h2>
             <span
@@ -196,10 +208,11 @@ const retrySubmission = () => {
               {{ typeLabel }}
             </span>
           </div>
-          <p class="text-gray-300">{{ currentRoutine.description }}</p>
+          <p class="text-body text-gray-300">
+            {{ currentRoutine.description }}
+          </p>
         </div>
 
-        <!-- 영상 (라벨 숨김) -->
         <RoutineVideo
           :video-url="currentRoutine.videoUrl"
           :show-label="false"
@@ -207,10 +220,7 @@ const retrySubmission = () => {
           @play="openVideo"
         />
 
-        <!-- 입력폼(응시 모드일 때만) / 완료 시 안내 -->
         <div v-if="isEntryMode" class="space-y-8">
-          <div class="text-subtext text-gray-200">답안 작성</div>
-
           <RoutineTypeSubjective
             v-if="isSubjective"
             :minimal="true"
@@ -232,47 +242,57 @@ const retrySubmission = () => {
         </div>
         <div
           v-else-if="isLocked"
-          class="mt-8 rounded-xl bg-gray-800 px-4 py-5 text-center text-gray-300"
+          class="bg-gray-custom mt-8 rounded-xl px-4 py-5 text-center text-gray-500"
         >
           이미 완료된 루틴입니다.
         </div>
       </template>
 
-      <!-- ====== 2) 영상 없는 케이스: 풀블랙 모달 (겉 카드만 테두리 유지) ====== -->
+      <!-- 2) 영상 없는 케이스: 배경 풀블랙 -->
       <template v-else>
+        <!-- 여기만 변경: bg-black/70 → bg-realBlack -->
         <div
           class="fixed inset-0 z-20 flex items-center justify-center bg-realBlack px-6"
         >
           <div
-            class="w-full max-w-[340px] rounded-2xl border border-[#2A2A2A] bg-[#1A1A1A] p-4 shadow-[0_12px_32px_rgba(0,0,0,0.6)]"
+            class="w-full max-w-[340px] rounded-[16px] bg-[#1A1A1A] p-5 shadow-[0_12px_32px_rgba(0,0,0,0.6)]"
           >
-            <!-- 닫기 -->
-            <button
-              class="ml-auto block rounded-full p-1 text-gray-400 hover:text-white"
-              @click="closeModal"
-            >
-              ✕
-            </button>
-
-            <!-- 타이틀/설명 -->
-            <div class="mb-6">
-              <div class="mb-1 flex items-center gap-2">
+            <!-- 상단 -->
+            <div class="flex items-start gap-3">
+              <img
+                :src="groupIcon"
+                alt="routine-icon"
+                class="h-12 w-12 flex-shrink-0 rounded-lg object-cover"
+              />
+              <div class="min-w-0 flex-1">
                 <h2 class="text-heading font-bold text-white">
                   {{ currentRoutine.title }}
                 </h2>
-                <span
-                  class="rounded-full bg-[#3A3A3A] px-2 py-[2px] text-[11px] leading-none text-white"
-                >
-                  {{ typeLabel }}
-                </span>
+                <div class="mt-1 flex flex-wrap items-center gap-2">
+                  <span
+                    class="rounded-full bg-[#2F2F2F] px-2 py-[2px] text-[11px] leading-none text-white"
+                    >{{ routineGroup }}</span
+                  >
+                  <span
+                    class="rounded-full bg-[#3A3A3A] px-2 py-[2px] text-[11px] leading-none text-white"
+                    >{{ typeLabel }}</span
+                  >
+                </div>
               </div>
-              <p class="text-gray-300">{{ currentRoutine.description }}</p>
+              <button
+                class="ml-1 rounded-full p-1 text-gray-400 transition hover:text-white"
+                @click="closeModal"
+                aria-label="close"
+              >
+                ✕
+              </button>
             </div>
 
-            <!-- 입력폼(응시 모드) / 완료 안내 -->
-            <div v-if="isEntryMode" class="space-y-6">
-              <div class="text-subtext text-gray-200">답안 작성</div>
+            <!-- 설명 -->
+            <p class="mt-4 text-gray-300">{{ currentRoutine.description }}</p>
 
+            <!-- 입력폼 (라벨 없음) -->
+            <div v-if="isEntryMode" class="mt-6 space-y-6">
               <RoutineTypeSubjective
                 v-if="isSubjective"
                 :minimal="true"
@@ -292,6 +312,7 @@ const retrySubmission = () => {
                 @submit="handleCertificationSubmit"
               />
             </div>
+
             <div
               v-else-if="isLocked"
               class="mt-6 rounded-xl bg-gray-800 px-4 py-5 text-center text-gray-300"
@@ -315,7 +336,6 @@ const retrySubmission = () => {
       </div>
     </main>
 
-    <!-- 결과 모달 -->
     <RoutineResultModal
       :is-visible="isResultModalVisible"
       :status="submissionStatus"

--- a/src/views/trainee/TraineeTrainingDetailPage.vue
+++ b/src/views/trainee/TraineeTrainingDetailPage.vue
@@ -324,7 +324,7 @@ const goToQnaPage = () => {
               <p class="text-input font-bold text-white">
                 {{ trainingData.trainerName }}
               </p>
-              <p class="text-body2 flex items-center gap-1 text-gray-300">
+              <p class="flex items-center gap-1 text-body2 text-gray-300">
                 수강생 {{ trainingData.studentCount.toLocaleString() }}
                 <img :src="StarIcon" alt="star" class="inline-block h-3 w-3" />
                 {{ trainingData.trainerRating || "-" }}
@@ -335,7 +335,7 @@ const goToQnaPage = () => {
           <!-- Q&A 버튼 -->
           <button
             @click="goToQnaPage"
-            class="text-input ml-auto rounded-full bg-primary px-3 py-1.5 font-bold text-black shadow"
+            class="ml-auto rounded-full bg-primary px-3 py-1.5 text-input font-bold text-black shadow"
           >
             Q&A
           </button>
@@ -397,7 +397,7 @@ const goToQnaPage = () => {
           :text="hasWrittenReview ? '리뷰 작성 완료' : '리뷰 작성하기'"
           :variant="hasWrittenReview ? 'disabled' : 'secondary'"
           :disabled="hasWrittenReview"
-          class="w-full"
+          class="bg-gray-custom w-full !text-body !font-medium !text-white"
           @click="!hasWrittenReview && goToReviewPage()"
         />
         <ActionButton
@@ -405,7 +405,7 @@ const goToQnaPage = () => {
           text="트레이너와 1:1 PT"
           variant="primary"
           :disabled="chatRoomCreated"
-          class="w-full"
+          class="!bg-gray-custom w-full !text-body !font-medium !text-white"
           @click="startChat"
         />
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,7 @@ export default {
       fontSize: {
         title: "28px",
         subTitle: "20px",
+        subTitle2: "18px",
         body: "15px",
         body2: "12px",
         body3: "10px",


### PR DESCRIPTION
## 📑 이슈 번호
- close #153

## ✨️ 작업 내용
- [x] 루틴 수행처리 타입별(OX, 실천형, 주관식) 디자인 변경
- [x] 동영상 유무에 따른 모달, 페이지 화면으로 분리
- [x] 루틴 수행 후 결과 모달 디자인 ㅂ녀경

## 💙 코멘트(선택)
세부적인 폰트 사이즈, 색 코드는 기능 수정 완료 후 전체적으로 변경 하겠습니다.

## 📸 구현 결과(선택)
