### PR TITLE
[Refactor] #166: 트레이너의 트레이닝 상세 페이지 디자인 수정 

### DIFF
--- a/src/components/common/BaseTabNavigation.vue
+++ b/src/components/common/BaseTabNavigation.vue
@@ -1,0 +1,76 @@
+<!-- TabNavigation.vue -->
+<script setup>
+import { ref, watch } from "vue";
+
+const props = defineProps({
+  tabs: {
+    type: Array,
+    required: true,
+    default: () => [],
+  },
+  defaultTab: {
+    type: String,
+    required: true,
+  },
+  containerClass: {
+    type: String,
+    default: "",
+  },
+});
+
+defineEmits(["tab-change"]);
+// 기본 탭 설정
+const activeTab = ref(
+  props.defaultTab || (props.tabs.length > 0 ? props.tabs[0].id : ""),
+);
+
+// 탭 변경 함수
+const setActiveTab = (tabId) => {
+  activeTab.value = tabId;
+  emit("tab-change", tabId);
+};
+
+// props.defaultTab이 변경되면 activeTab도 업데이트
+watch(
+  () => props.defaultTab,
+  (newTab) => {
+    if (newTab) {
+      activeTab.value = newTab;
+    }
+  },
+);
+</script>
+
+<template>
+  <div :class="containerClass">
+    <!-- 탭 네비게이션 -->
+    <div class="flex border-b border-gray-800 font-bold">
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        @click="setActiveTab(tab.id)"
+        :class="[
+          'flex-1 px-6 py-4 text-center text-sm font-medium transition-colors duration-200',
+          activeTab === tab.id
+            ? 'text-primary'
+            : 'text-gray-300 hover:text-primary',
+        ]"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+    <!-- 탭 컨텐츠 -->
+    <div class="mt-4">
+      <template v-for="tab in tabs" :key="`content-${tab.id}`">
+        <div v-if="activeTab === tab.id">
+          <slot :name="tab.id" :tab="tab" :active-tab="activeTab">
+            <!-- 기본 컨텐츠 (슬롯이 제공되지 않은 경우) -->
+            <div class="py-8 text-center text-gray-500">
+              {{ tab.label }} 컨텐츠가 없습니다.
+            </div>
+          </slot>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/src/components/training/TrainingInfo.vue
+++ b/src/components/training/TrainingInfo.vue
@@ -1,0 +1,111 @@
+<script setup>
+import { computed } from "vue";
+
+import BaseTag from "../common/BaseTag.vue";
+
+import star from "@/assets/images/star.svg";
+import nodata from "@/assets/images/mascot/nodata.png";
+
+// Props 정의
+const props = defineProps({
+  trainingData: {
+    type: Object,
+    required: true,
+    validator: (value) => {
+      return (
+        value && typeof value === "object" && value.title && value.description
+      );
+    },
+  },
+  userRole: {
+    type: String,
+    required: true,
+    validator: (value) => ["trainer", "trainee"].includes(value),
+  },
+});
+
+// role에 따른 추가 처리가 필요하다면 computed 사용
+const displayData = computed(() => {
+  const baseData = { ...props.trainingData };
+  return baseData;
+});
+</script>
+
+<template>
+  <div>
+    <!-- 고정된 썸네일과 제목 영역 - 두 개의 분리된 박스 -->
+    <div class="top-0">
+      <div class="flex pr-4 pt-3">
+        <!-- 썸네일 박스 (고정) -->
+        <div class="flex-shrink-0 overflow-hidden rounded-2xl px-3 py-4">
+          <div class="h-[163px] w-[108px] overflow-hidden rounded-xl">
+            <img
+              :src="trainingData.thumbnailUrl || nodata"
+              :alt="`${trainingData.title} 강의 썸네일`"
+              class="h-full w-full"
+              :class="
+                trainingData.thumbnailUrl ? 'object-cover' : 'object-contain'
+              "
+              @error="$event.target.src = nodata"
+            />
+          </div>
+        </div>
+
+        <!-- 내용 박스 (고정) -->
+        <div class="flex-1 rounded-2xl pt-7 text-white">
+          <!-- 제목 -->
+          <div
+            class="mb-4 line-clamp-3 overflow-hidden text-subTitle font-bold leading-tight"
+            style="display: -webkit-box; -webkit-box-orient: vertical"
+          >
+            {{ trainingData.title }}
+          </div>
+
+          <!-- 수강생 수와 별점 -->
+          <div class="mb-4 flex items-center gap-3 text-body text-gray-300">
+            <span class="flex items-center gap-1">
+              수강생 {{ trainingData.studentCount?.toLocaleString() || "0" }}
+            </span>
+            <span class="flex items-center gap-1">
+              <img :src="star" alt="별점" class="h-4 w-4" />
+              {{ trainingData.trainerRating || "4.8" }}
+            </span>
+          </div>
+
+          <!-- 태그 영역 -->
+          <div class="flex gap-1">
+            <!-- 초급 태그 (초록색) -->
+            <BaseTag
+              :text="trainingData.level || '초급'"
+              class="rounded-full bg-green-500 px-3 py-1.5 text-sm font-medium text-white"
+            />
+
+            <!-- 기타 태그들 (회색) -->
+            <BaseTag
+              :text="trainingData.category || '신용과 부채 관리'"
+              class="rounded-full bg-gray-600 px-3 py-1.5 text-sm font-medium text-white"
+            />
+
+            <BaseTag
+              :text="'0P'"
+              class="rounded-full bg-gray-600 px-3 py-1.5 text-sm font-medium text-white"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 트레이너 정보 (트레이니에게만 표시) -->
+    <div
+      v-if="userRole === 'trainee' && trainingData.trainerName"
+      class="mb-6 flex items-center gap-3 text-gray-300"
+    >
+      <img
+        :src="trainingData.trainerProfileUrl"
+        :alt="trainingData.trainerName"
+        class="h-8 w-8 rounded-full object-cover"
+      />
+      <span>{{ trainingData.trainerName }}</span>
+    </div>
+  </div>
+</template>

--- a/src/views/trainer/TrainerTrainingDetailPage.vue
+++ b/src/views/trainer/TrainerTrainingDetailPage.vue
@@ -2,11 +2,10 @@
 import { ref, onMounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
-import profileDefault from "@/assets/images/mascot/profile.png";
-
 import BaseHeader from "@/components/common/BaseHeader.vue";
-import BaseBadge from "@/components/common/BaseBadge.vue";
-import ReviewList from "@/components/common/ReviewList.vue";
+import BaseTabNavigation from "@/components/common/BaseTabNavigation.vue";
+
+import TrainingInfo from "@/components/training/TrainingInfo.vue";
 import TrainerRoutineSection from "@/components/trainer/training/TrainerRoutineSection.vue";
 
 import { getReviews } from "@/composables/api/useReviewApi";
@@ -20,6 +19,7 @@ const router = useRouter();
 
 const trainingData = ref(null);
 const reviewList = ref([]);
+const activeTab = ref("details"); //Navi
 const num = (v) => (v == null ? 0 : Number(v));
 
 const expandedSections = ref({
@@ -47,6 +47,18 @@ const goBack = () => {
 const toggleSection = (category) => {
   expandedSections.value[category] = !expandedSections.value[category];
 };
+
+// 탭 변경 핸들러
+const handleTabChange = (tabId) => {
+  activeTab.value = tabId;
+};
+
+// 탭 목록 정의
+const tabs = [
+  { id: "details", label: "상세 설명" },
+  { id: "reviews", label: "리뷰" },
+  { id: "qna", label: "QnA" },
+];
 
 onMounted(async () => {
   const trainingId = route.params.trainingId;
@@ -114,89 +126,67 @@ onMounted(async () => {
   }
 });
 </script>
-
 <template>
-  <div
-    v-if="trainingData"
-    class="min-h-screen overflow-y-auto bg-realBlack px-6 pb-20 pt-4 text-white"
-  >
-    <BaseHeader title="트레이닝 상세" @back="goBack" />
-
-    <div class="mt-4 flex items-center gap-2">
-      <BaseBadge>{{ trainingData.level }}</BaseBadge>
-      <BaseBadge>{{ trainingData.category }}</BaseBadge>
-      <BaseBadge variant="primary" class="ml-auto">
-        총 리워드 {{ trainingData.reward }}
-      </BaseBadge>
-    </div>
-
-    <div
-      class="mt-6 flex h-48 w-full items-center justify-center overflow-hidden rounded-lg bg-gray-800"
-    >
-      <img
-        :src="trainingData.thumbnailUrl"
-        alt="트레이닝 썸네일"
-        class="h-full w-full object-cover"
-      />
-    </div>
-
-    <div class="mt-6 flex items-center justify-between">
-      <div class="flex items-center gap-3 rounded-lg p-2">
-        <div
-          class="flex h-10 w-10 flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-gray-700"
-        >
-          <img
-            v-if="trainingData.trainerProfileUrl"
-            :src="trainingData.trainerProfileUrl"
-            alt="프로필"
-            class="h-full w-full object-cover"
-          />
-          <img
-            v-else
-            :src="profileDefault"
-            alt="기본 프로필"
-            class="h-full w-full"
-          />
-        </div>
-        <p class="font-bold text-white">{{ trainingData.trainerName }}</p>
-      </div>
-
-      <div class="flex items-center gap-2 text-caption text-gray-200">
-        <div class="flex items-center gap-1">
-          <img src="@/assets/images/star.svg" alt="별점" class="h-3 w-3" />
-          <span>{{ trainingData.trainerRating }}</span>
-        </div>
-        <span>|</span>
-        <span>{{ trainingData.studentCount }}명 수강</span>
-        <span>|</span>
-        <span>{{ trainingData.totalWeeks }}주</span>
-      </div>
-    </div>
-
-    <div class="mt-6">
-      <h2 class="text-heading font-bold">{{ trainingData.title }}</h2>
-      <p class="mt-2 text-body text-gray-300">
-        {{ trainingData.description }}
-      </p>
-    </div>
-
-    <div class="my-6 h-px bg-gray-800"></div>
-
-    <ReviewList :reviews="reviewList" />
-
-    <div class="my-6 h-px bg-gray-800"></div>
-
+  <div>
+    <BaseHeader @back="goBack()" title="트레이닝 상세"></BaseHeader>
     <div>
-      <h3 class="mb-4 text-xl font-bold">루틴 목록</h3>
-      <TrainerRoutineSection
-        v-for="(routines, category) in categorizedRoutines"
-        :key="category"
-        :title="sectionTitles[category]"
-        :routines="routines"
-        :is-expanded="expandedSections[category]"
-        :show-add-button="false"
-        @toggle="toggleSection(category)"
+      <TrainingInfo
+        v-if="trainingData"
+        :training-data="trainingData"
+        user-role="trainer"
       />
+    </div>
+
+    <!-- BaseTabNavigation 사용 -->
+    <div class="mx-3 my-3">
+      <BaseTabNavigation
+        :tabs="tabs"
+        :default-tab="'details'"
+        container-class=""
+        @tab-change="handleTabChange"
+      >
+        <!-- 상세 설명 탭 컨텐츠 -->
+        <template #details>
+          <div>
+            <!-- 트레이닝 설명 -->
+            <div v-if="trainingData?.description" class="mx-2 mb-6">
+              <div class="border-l-4p-4 mb-4 rounded-lg">
+                <p class="text-body leading-relaxed text-gray-300">
+                  {{ trainingData.description }}
+                </p>
+              </div>
+            </div>
+
+            <!-- 루틴 목록 -->
+            <div>
+              <div class="mb-2 ml-2 text-body font-bold">루틴 목록</div>
+              <TrainerRoutineSection
+                v-for="(routines, category) in categorizedRoutines"
+                :key="category"
+                :title="sectionTitles[category]"
+                :routines="routines"
+                :is-expanded="expandedSections[category]"
+                :show-add-button="false"
+                @toggle="toggleSection(category)"
+              />
+            </div>
+          </div>
+        </template>
+
+        <!-- 리뷰 탭 컨텐츠 -->
+        <template #reviews>
+          <div class="space-y-4">
+            <div class="py-8 text-center text-gray-500">리뷰가 없습니다.</div>
+          </div>
+        </template>
+
+        <!-- QnA 탭 컨텐츠 -->
+        <template #qna>
+          <div class="py-8 text-center text-gray-500">
+            <p>QnA가 없습니다.</p>
+          </div>
+        </template>
+      </BaseTabNavigation>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## 📑 이슈 번호
- close #166 

## ✨️ 작업 내용
- [x] 트레이닝 상세 페이지 수정
- [x] 트레이닝 상세 내부 네비탭 추가 

## 💙 코멘트(선택)

## 📸 구현 결과(선택)
<img width="204" height="423" alt="image" src="https://github.com/user-attachments/assets/3524f245-eb2e-427b-a6b0-53455a286968" />
<img width="282" height="404" alt="image" src="https://github.com/user-attachments/assets/042d7e3d-625d-497a-b9d1-3f61de6cd6ba" />