### PR TITLE
[Fix] #166 : 트레이닝 상세 컨텐츠 잘리는 현상 수정

### DIFF
--- a/src/components/common/BaseTabNavigation.vue
+++ b/src/components/common/BaseTabNavigation.vue
@@ -18,7 +18,8 @@ const props = defineProps({
   },
 });
 
-defineEmits(["tab-change"]);
+const emit = defineEmits(["tab-change"]);
+
 // 기본 탭 설정
 const activeTab = ref(
   props.defaultTab || (props.tabs.length > 0 ? props.tabs[0].id : ""),
@@ -60,7 +61,7 @@ watch(
       </button>
     </div>
     <!-- 탭 컨텐츠 -->
-    <div class="mt-4">
+    <div class="mt-4 min-h-screen">
       <template v-for="tab in tabs" :key="`content-${tab.id}`">
         <div v-if="activeTab === tab.id">
           <slot :name="tab.id" :tab="tab" :active-tab="activeTab">

--- a/src/components/training/TrainingInfo.vue
+++ b/src/components/training/TrainingInfo.vue
@@ -24,10 +24,23 @@ const props = defineProps({
   },
 });
 
-// role에 따른 추가 처리가 필요하다면 computed 사용
-const displayData = computed(() => {
-  const baseData = { ...props.trainingData };
-  return baseData;
+// 레벨 배지 (오른쪽 상단)
+const levelBadge = computed(() => {
+  const level = props.trainingData.level || "초급";
+  let backgroundColor;
+  switch (level) {
+    case "고급":
+      backgroundColor = "#FF4141";
+      break;
+    case "중급":
+      backgroundColor = "#5141FF";
+      break;
+    case "초급":
+    default:
+      backgroundColor = "#008407";
+  }
+
+  return { text: level, backgroundColor };
 });
 </script>
 
@@ -76,8 +89,12 @@ const displayData = computed(() => {
           <div class="flex gap-1">
             <!-- 초급 태그 (초록색) -->
             <BaseTag
-              :text="trainingData.level || '초급'"
-              class="rounded-full bg-green-500 px-3 py-1.5 text-sm font-medium text-white"
+              v-if="levelBadge"
+              :text="levelBadge.text"
+              class="inline-block break-words rounded-xl bg-gray-900 px-2 py-1 text-center text-[7px] leading-tight text-white"
+              :style="{
+                backgroundColor: levelBadge.backgroundColor,
+              }"
             />
 
             <!-- 기타 태그들 (회색) -->


### PR DESCRIPTION
## 📑 이슈 번호
- close #166 

## ✨️ 작업 내용
- [x] 트레이닝 상세 컨텐츠 잘리는 현상 수정

## 💙 코멘트(선택)

## 📸 구현 결과(선택)
<img width="222" height="446" alt="image" src="https://github.com/user-attachments/assets/d760dfea-9c5d-4ef9-93aa-9b4e36883451" />